### PR TITLE
feat(backend): model resource, add CRUD, soft delete and testing endpoints

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -489,6 +490,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/back/package.json
+++ b/back/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "dotenv": "^17.2.1",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/back/src/app.ts
+++ b/back/src/app.ts
@@ -1,7 +1,13 @@
 import express from 'express'; 
 import router from './routes';
+import dotenv from 'dotenv';
+import connectDB from './config/database';
+
+dotenv.config();
 
 const app = express();
+connectDB();
+
 app.use(express.json());
 
 app.use('/api', router);

--- a/back/src/config/database.ts
+++ b/back/src/config/database.ts
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI || "");
+    console.log("Base de datos conectada");
+  } catch (error) {
+    console.error("Error al conectar a la base de datos:", error);
+    process.exit(1);
+  }
+};
+
+export default connectDB;

--- a/back/src/controllers/resourceController.ts
+++ b/back/src/controllers/resourceController.ts
@@ -1,0 +1,94 @@
+import { Request, Response } from 'express';
+import { ResourceService } from '../services/resourceService';
+
+const resourceService = new ResourceService();
+
+export const getResources = async (req: Request, res: Response) => {
+    try {
+        const resources = await resourceService.getAllResources();
+        res.status(200).json({
+            success: true,
+            message: "Recursos obtenidos correctamente",
+            data: resources
+        });
+    } catch (error) {
+        console.error('Error al obtener los recursos:', error);
+        res.status(500).json({ success: false, message: "Error al obtener los recursos" });
+    }
+}
+
+export const createResource = async (req: Request, res: Response) => {
+    try {
+        const resource = await resourceService.createResource(req.body);
+        res.status(201).json({
+            success: true,
+            message: "Recurso creado correctamente",
+            data: resource
+        });
+    } catch (error) {
+        res.status(500).json({ success: false, message: "Error al crear el recurso" });
+    }
+};
+export const getResourceById = async (req: Request, res: Response) => {
+    try {
+        const resource = await resourceService.getResourceById(req.params.id);
+        if (!resource) {
+            return res.status(404).json({ success: false, message: "Recurso no encontrado" });
+        }
+        res.json({success: true, data: resource});
+    } catch (error) {
+        res.status(500).json({ success: false, message: "Error al obtener el recurso" });
+    }
+};
+
+export const getResourcesBySection = async (req: Request, res: Response) => {
+    try {
+        const resources = await resourceService.getResourcesBySection(req.params.sectionId);
+        res.json({
+            success: true,
+            message: "Recursos obtenidos correctamente",
+            data: resources
+        });
+    } catch (error) {
+        res.status(500).json({ success: false, message: "Error al obtener los recursos" });
+    }
+}
+
+export const updateResource = async (req: Request, res: Response) => {
+    try {
+        const resource = await resourceService.updateResource(req.params.id, req.body);
+        if (!resource) {
+            return res.status(404).json({ success: false, message: "Recurso no encontrado" });
+        }
+        res.json({success: true, message: "Recurso actualizado correctamente", data: resource});
+    } catch (error) {
+        res.status(500).json({ success: false, message: "Error al actualizar el recurso" });
+    }
+};
+
+export const deleteResource = async (req: Request, res: Response) => {
+    try {
+        const resource = await resourceService.softDeleteResource(req.params.id);
+        if (!resource) {
+            return res.status(404).json({success: false, message: 'Recurso no encontrado' });
+        }
+        res.status(200).json({ success: true, message: 'Recurso eliminado(soft delete) correctamente', data: resource });
+    } catch (error) {
+        res.status(500).json({ success: false, message: 'Error al eliminar el recurso' });
+    }
+    
+};
+
+//Función para restaurar un recurso (en caso de necesitarlo)
+export const restoreResource = async (req: Request, res: Response) => {
+  try {
+    const resource = await resourceService.restoreResource(req.params.id);
+    if (!resource) {
+      return res.status(404).json({ success: false, message: "Recurso no encontrado" });
+    }
+    return res.status(200).json({ success: true, message: "Recurso restaurado correctamente", data: resource });
+  } catch (error) {
+    console.error("Error al restaurar recurso:", error);
+    return res.status(500).json({ success: false, message: "Error al restaurar recurso" });
+  }
+};

--- a/back/src/models/Resource.ts
+++ b/back/src/models/Resource.ts
@@ -1,0 +1,36 @@
+import mongoose, {Schema, model, Document} from 'mongoose';
+
+export interface IResource extends Document {
+  sectionId: Schema.Types.ObjectId;
+  name: string;
+  description?: string;
+  link: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+const resourceSchema = new Schema<IResource>(
+  {
+    sectionId: {type: Schema.Types.ObjectId, ref: 'Section', required: true},
+    name: {type: String, required: true},
+    description: {type: String},
+    link: {type: String, required: true},
+    isActive: {type: Boolean, default: true},
+    deletedAt: {type: Date, default: null},
+  },
+  {timestamps: true}
+);
+
+// Middleware para excluir soft deleted en consultas find, findOne, etc
+resourceSchema.pre(/^find/, function (this: mongoose.Query<IResource[], IResource>, next) {
+  const includeDeleted = this.getOptions().includeDeleted;
+  if (!includeDeleted) {
+    this.where({ isActive: true, deletedAt: null });
+  }
+  next();
+});
+
+const Resource = model<IResource>('Resource', resourceSchema);
+export default Resource;

--- a/back/src/routes/index.ts
+++ b/back/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import userRouter from './userRoutes';
+import resourceRouter from './resourceRoutes';
 
 const router = Router();
 
@@ -8,5 +9,6 @@ router.get('/', (_req, res) => {
 });
 
 router.use('/users', userRouter);
+router.use('/resources', resourceRouter);
 
 export default router;

--- a/back/src/routes/resourceRoutes.ts
+++ b/back/src/routes/resourceRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { getResources, createResource, getResourceById, getResourcesBySection, updateResource, deleteResource, restoreResource } from "../controllers/resourceController";
+
+const resourceRouter = Router();
+
+resourceRouter.get("/", getResources);
+resourceRouter.post("/", createResource);
+resourceRouter.get("/:id", getResourceById);
+resourceRouter.get("/section/:sectionId", getResourcesBySection);
+resourceRouter.put("/:id", updateResource);
+resourceRouter.delete("/:id", deleteResource);
+resourceRouter.patch("/restore/:id", restoreResource);
+
+export default resourceRouter;

--- a/back/src/services/resourceService.ts
+++ b/back/src/services/resourceService.ts
@@ -1,0 +1,52 @@
+import mongoose from "mongoose";
+import Resource, { IResource } from "../models/Resource";
+
+export class ResourceService {
+    async getAllResources(): Promise<IResource[]> {
+        return Resource.find().exec();
+    }
+    async createResource(data: Partial<IResource>): Promise<IResource> {
+        const resource = new Resource(data);
+        return resource.save();
+    }
+
+    async getResourceById(id: string): Promise<IResource | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+        return Resource.findById(id).exec();
+    }
+
+    async updateResource(id: string, data: Partial<Omit<IResource, "createdAt" | "updatedAt">>
+    ): Promise<IResource | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+        return Resource.findOneAndUpdate({ _id: id }, data, { new: true }).exec();
+    }
+
+    async softDeleteResource(id: string): Promise<IResource | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+        return Resource.findByIdAndUpdate(id, { isActive: false, deletedAt: new Date() }, { new: true }).exec();
+    }
+
+    async getResourcesBySection(sectionId: string): Promise<IResource[]> {
+        return Resource.find({ sectionId }).exec();
+    }
+
+    //Método para restaurar un recurso
+    async restoreResource(id: string): Promise<IResource | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+
+        // Buscar incluso recursos eliminados
+        const resource = await Resource.findById(id).setOptions({ includeDeleted: true });
+        if (!resource) return null;
+
+        // Restaurar solo si estaba eliminado
+        if (!resource.isActive || resource.deletedAt) {
+            resource.isActive = true;
+            resource.deletedAt = null;
+            return resource.save();
+        }
+
+        return resource; // Si ya estaba activo, lo devolvemos igual
+    }
+
+
+};


### PR DESCRIPTION
Este PR está relacionado con la creación del modelo, servicio, controlador y rutas de Resource (Links de los documentos de Scala).
 
Se implementa el CRUD completo para la entidad Resource, incluyendo:
- GET, POST, PUT, DELETE (soft delete) y PATCH (restore).
- Middleware pre-find para excluir soft deleted por defecto al realizar filtros.
- Restauración de recursos eliminados (por si el equipo lo necesita en el futuro).
- Validación de ObjectId y manejo de errores.

**Notas:**
- Los recursos eliminados se filtran automáticamente en consultas normales.
- Se puede restaurar cualquier recurso eliminado con PATCH /resources/restore/:id 

**Endpoints implementados:**

- GET _/resources_ → Obtener todos los recursos (excluye soft deleted por defecto).
- GET _/resources/:id_ → Obtener recurso por ID.
- GET _/resources/section/:sectionId_ → Obtener recursos por sección.
- POST _/resources_ → Crear nuevo recurso.
- PUT _/resources/:id_ → Actualizar recurso por ID.
- DELETE _/resources/:id_ → Soft delete (marca isActive = false y deletedAt con fecha actual).
- PATCH _/resources/restore/:id_ → Restaurar recurso previamente eliminado.

**Middleware Mongoose:**

Se añadió un pre-hook en el modelo: pre(/^find/) asegurando que cualquier find o findOne excluya los recursos eliminados (soft delete) al realizar los filtros.

Solo se incluyen eliminados si se pasa la opción { includeDeleted: true }.

**Validaciones:**

- Se valida que el id sea un ObjectId válido antes de cualquier operación.
- Respuestas claras cuando la petición es exitosa o si hubo un problema.

Pruebas realizadas en _ThunderClient_ y _Postman_. 


