### PR TITLE
Feature/backend auth resource

### DIFF
--- a/back/src/routes/resourceRoutes.ts
+++ b/back/src/routes/resourceRoutes.ts
@@ -1,14 +1,21 @@
 import { Router } from "express";
 import { getResources, createResource, getResourceById, getResourcesBySection, updateResource, deleteResource, restoreResource } from "../controllers/resourceController";
+import { authMiddleware } from "../middlewares/auth.middleware";
+import { verifyAdmin } from "../middlewares/verifyAdmin.middleware";
 
 const resourceRouter = Router();
 
-resourceRouter.get("/", getResources);
-resourceRouter.post("/", createResource);
-resourceRouter.get("/:id", getResourceById);
-resourceRouter.get("/section/:sectionId", getResourcesBySection);
-resourceRouter.put("/:id", updateResource);
-resourceRouter.delete("/:id", deleteResource);
-resourceRouter.patch("/restore/:id", restoreResource);
+//Todos los usuarios autenticados pueden ver los recursos o filtrar por seccion
+resourceRouter.get("/", authMiddleware, getResources);
+resourceRouter.get("/:id", authMiddleware, getResourceById);
+resourceRouter.get("/section/:sectionId", authMiddleware, getResourcesBySection);
+
+//Todos los usuarios autenticados pueden crear y actualizar recursos
+resourceRouter.post("/", authMiddleware, createResource);
+resourceRouter.put("/:id", authMiddleware, updateResource);
+
+//Solo Admin puede eliminar (soft delete) y restaurar recursos
+resourceRouter.delete("/:id", authMiddleware, verifyAdmin, deleteResource);
+resourceRouter.patch("/restore/:id", authMiddleware, verifyAdmin, restoreResource);
 
 export default resourceRouter;


### PR DESCRIPTION
Este PR actualiza la estructura de datos de los Resources (Links), ajustando los permisos en el archivo de resourceRoutes de la siguiente manera: 

- GET → cualquier usuario autenticado puede ver recursos.
- POST / PUT → cualquier usuario autenticado puede crear o editar recursos.
- DELETE / PATCH restore → solo Admin puede eliminar y restaurar recursos (soft delete).

Pruebas:
Se realizaron las pruebas en Postman tanto del CRUD completo como token expirado o inválido. Funcionando todo OK.