### PR TITLE
feat(backend): crear estructura de datos para secciones de Scala y me…

### DIFF
--- a/back/src/controllers/sectionController.ts
+++ b/back/src/controllers/sectionController.ts
@@ -1,0 +1,121 @@
+import { Request, Response } from "express";
+import { SectionService } from "../services/sectionService";
+
+const sectionService = new SectionService();
+
+export const getSections = async (req: Request, res: Response) => {
+  try {
+    const sections = await sectionService.getAllSections();
+    res.json({
+      success: true,
+      message: "Secciones obtenidas exitosamente",
+      data: sections,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: "Error interno del servidor al obtener las secciones",
+    });
+  }
+};
+
+export const getSectionById = async (req: Request, res: Response) => {  
+    try {
+        const section = await sectionService.getSectionById(req.params.id);
+        if (!section) {
+            return res.status(404).json({
+                success: false,
+                error: "Sección no encontrada"
+            });
+        }   
+        res.json({
+            success: true,
+            message: "Sección obtenida exitosamente",
+            data: section
+        });
+    } catch (error) {
+        res.status(500).json({  
+            success: false,
+            error: "Error interno del servidor al obtener la sección"
+        });
+    }   
+};
+
+export const createSection = async (req: Request, res: Response) => {
+    try {
+        const section = await sectionService.createSection(req.body);
+        res.status(201).json({
+            success: true,
+            message: "Sección creada exitosamente",
+            data: section
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            error: "Error interno del servidor al crear la sección"
+        });
+    }
+};
+export const updateSection = async (req: Request, res: Response) => {
+    try {
+        const section = await sectionService.updateSection(req.params.id, req.body);
+        if (!section) {
+            return res.status(404).json({
+                success: false,
+                error: "Sección no encontrada"
+            });
+        }
+        res.json({
+            success: true,
+            message: "Sección actualizada exitosamente",
+            data: section
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            error: "Error interno del servidor al actualizar la sección"
+        });
+    }
+};
+export const softDeleteSection = async (req: Request, res: Response) => {
+    try {
+        const section = await sectionService.softDeleteSection(req.params.id);
+        if (!section) {
+            return res.status(404).json({
+                success: false,
+                error: "Sección no encontrada"
+            });
+        }
+        res.json({
+            success: true,
+            message: "Sección eliminada exitosamente",
+            data: section
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            error: "Error interno del servidor al eliminar la sección"
+        });
+    }
+};
+export const restoreSection = async (req: Request, res: Response) => {
+    try {
+        const section = await sectionService.restoreSection(req.params.id);
+        if (!section) {
+            return res.status(404).json({
+                success: false,
+                error: "Sección no encontrada"
+            });
+        }
+        res.json({
+            success: true,
+            message: "Sección restaurada exitosamente",
+            data: section
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            error: "Error interno del servidor al restaurar la sección"
+        });
+    }
+};

--- a/back/src/controllers/userController.ts
+++ b/back/src/controllers/userController.ts
@@ -10,7 +10,11 @@ export const getUsers = async (
 ): Promise<void> => {
   try {
     const users = await userService.getUsers();
-    res.json(users);
+    res.status(200).json({
+      success: true,
+      message: "Usuarios obtenidos con éxito",
+      data: users,
+    });
   } catch (error) {
     next(error);
   }
@@ -39,7 +43,11 @@ export const getUserById = async (
   try {
     const id = req.params.id;
     const user = await userService.getUserById(id);
-    if (user) res.json(user);
+    if (user) res.status(200).json({
+      success: true,
+      message: "Usuario obtenido con éxito",
+      data: user,
+    });
     else res.status(404).json({ message: "Usuario no encontrado" });
   } catch (error) {
     next(error);
@@ -54,12 +62,12 @@ export const createUser = async (
   try {
     const userData = req.body;
     const user = await userService.createUser(userData);
-    res.status(201).json({ user, message: "Usuario creado con éxito" });
+    res.status(201).json({ success: true, message: "Usuario creado con éxito", data: user });
   } catch (error: any) {
     if (error && error.status && error.error) {
-      res.status(error.status).json({ error: error.error });
+      res.status(error.status).json({ success: false, error: error.error });
     } else {
-      res.status(500).json({ error: "Error inesperado al crear usuario" });
+      res.status(500).json({ success: false, error: "Error inesperado al crear usuario" });
     }
   }
 };
@@ -72,7 +80,7 @@ export const login = async (
   try {
     const { email, password } = req.body;
     const [user, token] = await userService.loginService({ email, password });
-    res.status(200).json({ user, token, message: "Login exitoso" });
+    res.status(200).json({ success: true, message: "Login exitoso", data: { user, token } });
   } catch (error) {
     next(error);
   }
@@ -89,11 +97,11 @@ export const resetAdminPassword = async (
     res.json({ message: "Contraseña actualizada con éxito", user });
   } catch (error: any) {
     if (error && error.status && error.error) {
-      res.status(error.status).json({ error: error.error });
+      res.status(error.status).json({ success: false, error: error.error });
     } else {
       res
         .status(500)
-        .json({ error: "Error inesperado al actualizar contraseña" });
+        .json({ success: false, error: "Error inesperado al actualizar contraseña" });
     }
   }
 };
@@ -107,8 +115,8 @@ export const updateUser = async (
     const id = req.params.id;
     const updatedData = req.body;
     const updatedUser = await userService.updateUser(id, updatedData);
-    if (updatedUser) res.json(updatedUser);
-    else res.status(404).json({ message: "Usuario no encontrado" });
+    if (updatedUser) res.json({ success: true, message: "Usuario actualizado con éxito", data: updatedUser });
+    else res.status(404).json({ success: false, message: "Usuario no encontrado" });
   } catch (error) {
     next(error);
   }
@@ -122,7 +130,7 @@ export const deleteUser = async (
   try {
     const id = req.params.id;
     await userService.deleteUser(id);
-    res.json({ message: "Usuario inactivado con éxito" });
+    res.json({ success: true, message: "Usuario inactivado con éxito" });
   } catch (error) {
     next(error);
   }
@@ -136,8 +144,8 @@ export const restoreUser = async (
   try {
     const id = req.params.id;
     const restoredUser = await userService.restoreUser(id);
-    if (restoredUser) res.json(restoredUser);
-    else res.status(404).json({ message: "Usuario no encontrado" });
+    if (restoredUser) res.json({ success: true, message: "Usuario restaurado con éxito", data: restoredUser });
+    else res.status(404).json({ success: false, message: "Usuario no encontrado" });
   } catch (error) {
     next(error);
   }
@@ -153,12 +161,13 @@ export const changeRole = async (
     const updatedUser = await userService.updateRole(id);
     if (updatedUser) {
       res.json({
+        success: true,
         message: `Rol actualizado a ${updatedUser.role}`,
         role: updatedUser.role,
         user: updatedUser,
       });
     } else {
-      res.status(404).json({ message: "Usuario no encontrado" });
+      res.status(404).json({ success: false, message: "Usuario no encontrado" });
     }
   } catch (error) {
     next(error);

--- a/back/src/middlewares/verifyAdmin.middleware.ts
+++ b/back/src/middlewares/verifyAdmin.middleware.ts
@@ -9,7 +9,7 @@ export const verifyAdmin = (
     return res.status(403).json({
       success: false,
       error:
-        "No tienes permisos para acceder a este recurso. Solo los administradores pueden realizar esta acción.",
+        "No tienes permisos para acceder a este recurso. Solo el administrador puede realizar esta acción.",
       statusCode: 403,
     });
   }

--- a/back/src/models/Resource.ts
+++ b/back/src/models/Resource.ts
@@ -4,7 +4,10 @@ export interface IResource extends Document {
   sectionId: Schema.Types.ObjectId;
   name: string;
   description?: string;
-  link: string;
+  links: {
+    label?: string; //Ejemplo: "EAFIT", "Directorio de contactos", etc.
+    url: string;
+  }[];
   isActive: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -16,7 +19,12 @@ const resourceSchema = new Schema<IResource>(
     sectionId: {type: Schema.Types.ObjectId, ref: 'Section', required: true},
     name: {type: String, required: true},
     description: {type: String},
-    link: {type: String, required: true},
+    links: [
+      {
+        label: {type: String},
+        url: {type: String, required: true},
+      },
+    ],
     isActive: {type: Boolean, default: true},
     deletedAt: {type: Date, default: null},
   },

--- a/back/src/models/Section.ts
+++ b/back/src/models/Section.ts
@@ -1,0 +1,37 @@
+import mongoose, { Document, model, Schema } from "mongoose";
+
+export interface ISection extends Document {
+    sectionId: Schema.Types.ObjectId;
+    title: string;
+    description: string;
+    resources: Schema.Types.ObjectId;
+    isActive: boolean;
+}
+
+const sectionSchema = new Schema<ISection>({
+    sectionId: {
+        type: Schema.Types.ObjectId
+    },
+    title: {
+        type: String,
+        required: true
+    },
+    description: { 
+        type: String, 
+        required: true 
+    },
+    resources: { 
+        type: Schema.Types.ObjectId, 
+        ref: "Resource" 
+    },
+    isActive: { 
+        type: Boolean, 
+        default: true 
+    },
+},
+    { timestamps: true }
+);
+
+const Section = model<ISection>('Section', sectionSchema);
+
+export default Section;

--- a/back/src/routes/index.ts
+++ b/back/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import userRouter from './userRoutes';
 import allianceRouter from './allianceRoutes';
 import resourceRouter from './resourceRoutes';
+import sectionRouter from './sectionRoutes';
 
 const router = Router();
 
@@ -12,5 +13,6 @@ router.get('/', (_req, res) => {
 router.use('/users', userRouter);
 router.use('/alliances', allianceRouter)
 router.use('/resources', resourceRouter);
+router.use('/sections', sectionRouter);
 
 export default router;

--- a/back/src/routes/sectionRoutes.ts
+++ b/back/src/routes/sectionRoutes.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import {
+  getSections,
+  getSectionById,
+  createSection,
+  updateSection,
+  softDeleteSection,
+  restoreSection
+} from "../controllers/sectionController";
+import { authMiddleware } from "../middlewares/auth.middleware";
+import { verifyAdmin } from "../middlewares/verifyAdmin.middleware";
+
+const sectionRouter = Router();
+
+sectionRouter.get("/", authMiddleware, getSections);
+sectionRouter.get("/:id", authMiddleware, getSectionById);
+sectionRouter.post("/", authMiddleware, createSection);
+sectionRouter.put("/:id", authMiddleware, updateSection);
+sectionRouter.delete("/:id", authMiddleware, verifyAdmin, softDeleteSection);
+sectionRouter.post("/:id/restore", authMiddleware, verifyAdmin, restoreSection);
+
+export default sectionRouter;

--- a/back/src/services/sectionService.ts
+++ b/back/src/services/sectionService.ts
@@ -1,0 +1,43 @@
+import mongoose from "mongoose";
+import Section, { ISection } from "../models/Section";
+
+export class SectionService {
+    async getAllSections(): Promise<ISection[]> {
+        return await Section.find().exec();
+    }       
+    async createSection(data: Partial<ISection>): Promise<ISection> {
+        const section = new Section(data);
+        return await section.save();
+    }
+    async getSectionById(id: string): Promise<ISection | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+        return await Section.findById(id).exec();
+    }
+    async updateSection(id: string, data: Partial<Omit<ISection, "createdAt" | "updatedAt">>
+    ): Promise<ISection | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+        return await Section.findOneAndUpdate({ _id: id }, data, { new: true }).exec();
+    }
+    async softDeleteSection(id: string): Promise<ISection | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+        return await Section.findByIdAndUpdate(id, { isActive: false }, { new: true }).exec();
+    }
+    async getSectionsByResource(resourceId: string): Promise<ISection[]> {
+        return await Section.find({ resourceId }).exec();
+    }
+    //Método para restaurar una sección
+    async restoreSection(id: string): Promise<ISection | null> {
+        if (!mongoose.Types.ObjectId.isValid(id)) return null;
+
+        // Buscar incluso secciones eliminadas
+        const section = await Section.findById(id).setOptions({ includeDeleted: true });
+        if (!section) return null;
+
+        // Restaurar solo si estaba eliminada
+        if (!section.isActive) {
+            section.isActive = true;
+            return await section.save();
+        }
+        return await Section.findByIdAndUpdate(id, { isActive: true }, { new: true }).exec();
+    }
+};


### PR DESCRIPTION
Este PR incluye la creación del modelo de Section (Secciones) y actualización de datos y carga inicial de información en la base de datos de MongoDB para el MVP de Scala.

**PRINCIPALES CAMBIOS**

**Modelo Resource**
Se modificó la estructura para soportar múltiples links por recurso, reemplazando el campo único link: string por:

> links: [{ label?: string; url: string }]

Esto permite manejar recursos con más de un enlace asociado, como el _Directorio de contactos de la alianza_.


**Datos iniciales en la BD**

**1. Creación de 3 usuarios base con roles:**

 _Admin_ (con credenciales y isAdmin: true)
_Director_
_User_

**2. Ingreso de las 7 secciones principales del sistema**

1. Nuestra Alianza
2. Gobernanza
3. Planeación
4. Gestión
5. Iniciativas
6. Galería de Fotos e Hitos de la Alianza
7. Chat IA

**3. Asociación de recursos reales a cada sección, incluyendo _descripciones_ y _enlaces externos_.**

> _Ejemplo_: el recurso “Directorio de contactos de la alianza” ahora contiene un array con múltiples links (EAFIT, UNAB, UDD, etc.).

**Pruebas en Postman**

- Se validó la creación de usuarios, login y generación de tokens JWT.
- Se probó la creación de secciones vía POST /api/sections.
- Se probó la creación de recursos con uno y varios links vía POST /api/resources.

✅ **Checklist**

-  Actualizado el modelo Resource para múltiples enlaces.
-  Datos iniciales cargados en la BD (usuarios, alianzas, secciones y recursos).
-  Validación de login con roles (admin, director, user).
-  Pruebas exitosas en Postman de rutas de usuarios, secciones, alianzas y recursos. 

🚀 **Impacto**
> 
> Se estandariza la forma de manejar recursos, permitiendo flexibilidad en la carga de documentos, enlaces y directorios.
> Se deja lista la base de datos con información real para pruebas de integración y demos del MVP.