### PR TITLE
feat(backend):integrar cors en app.ts para el consumo de frontend y c…

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -1,0 +1,114 @@
+# 📌 ScalaLearning - Backend
+
+Backend del proyecto **ScalaLearning**, desarrollado en **Node.js + Express + TypeScript**, con base de datos en **MongoDB**.
+Incluye autenticación con JWT, control de roles (admin, director, usuario), y gestión de secciones, recursos y alianzas.
+
+---
+
+## 🚀 Tecnologías
+
+* [Node.js]
+* [Express]
+* [TypeScript]
+* [MongoDB] + [Mongoose]
+* [JWT] para autenticación
+* [bcrypt] para encriptación de contraseñas
+
+---
+
+## ⚙️ Requisitos previos
+
+* Node.js v18+
+* MongoDB (local o en la nube)
+* Postman (opcional, para pruebas)
+
+---
+
+## 📂 Instalación y ejecución
+
+1. Clonar el repositorio:
+
+   ```bash
+   git clone https://github.com/diazarm/TechXcelerators_6.git
+   cd nombre_carpeta
+   ```
+
+2. Instalar dependencias:
+
+   ```bash
+   npm install
+   ```
+
+3. Crear el archivo `.env` en la raíz del proyecto:
+
+   ```env
+   MONGODB_URI=mongodb://localhost:27017/scala_mvp
+   JWT_SECRET=tu_clave_secreta
+   PORT=3000
+   SECRET_KEY=tu_clave
+   JWT_EXPIRATION=3600
+   ```
+
+4. Ejecutar en modo desarrollo:
+
+   ```bash
+   npm run dev
+   ```
+
+5. Compilar y ejecutar en producción:
+
+   ```bash
+   npm run build
+   npm run start
+   ```
+
+---
+
+## 🔑 Roles y permisos
+
+* **Admin** → acceso total al sistema, gestión completa (usuarios, secciones, recursos, alianzas).
+* **Director** → acceso total al sistema, puede eliminar/restaurar recursos y alianzas y no gestiona usuarios.
+* **Usuario** → acceso al sistema pero con algunas restricciones, no puede eliminar o restaurar datos y no gestiona usuarios.
+
+---
+
+## 📌 Endpoints principales
+
+| Módulo    | Endpoint base    | Acciones principales       |
+| --------- | ---------------- | -------------------------- |
+| Users     | `/api/users`     | CRUD, login, roles         |
+| Sections  | `/api/sections`  | CRUD (solo admin)          |
+| Resources | `/api/resources` | CRUD, soft delete, restore |
+| Alliances | `/api/alliances` | CRUD, soft delete, restore |
+
+---
+
+## 🧪 Postman
+
+En la carpeta `/postman` encontrarás:
+
+* `ScalaLearning.postman_collection.json` → rutas de la API.
+* `ScalaLearning.postman_environment.json` → variables (`{{baseUrl}}`, `{{token}}`).
+
+### Flujo recomendado:
+
+1. Ejecutar **Login** con admin/director/usuario.
+2. El token se guarda en la variable `{{token}}`.
+3. Usar cualquier ruta protegida automáticamente con `Bearer {{token}}`.
+
+---
+
+## ☁️ Deploy
+
+El backend se desplegará en:
+
+* **Render**.
+* Base de datos en **MongoDB Atlas** (recomendado para producción).
+
+---
+
+## 👨‍💻 Equipo
+
+* Backend: \[Alex Ancelovici, Rebeca Vargas y Christopher Pesántez (TL)]
+
+---

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.1.0",
         "bcrypt": "^6.0.0",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.2.0",
@@ -129,6 +130,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -535,6 +546,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/create-require": {
@@ -1425,6 +1449,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/back/package.json
+++ b/back/package.json
@@ -13,8 +13,8 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "express": "^5.1.0",
     "bcrypt": "^6.0.0",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.2.0",

--- a/back/postman/.ENV.postman_environment.json
+++ b/back/postman/.ENV.postman_environment.json
@@ -1,0 +1,15 @@
+{
+	"id": "039249a0-c4bd-4437-b3dd-9d554bad609d",
+	"name": ".ENV",
+	"values": [
+		{
+			"key": "token",
+			"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiI2OGM5ZGNjM2FlMDczN2YzMWI5NmQ0MDciLCJuYW1lIjoiQ2FybG9zIEFuZHJhZGUiLCJlbWFpbCI6ImFkbWluQHNjYWxhLmNvbSIsImlzQWRtaW4iOnRydWUsInJvbGUiOiJ1c2VyIiwiaWF0IjoxNzU4NjQzMDI5LCJleHAiOjE3NTg2NDY2Mjl9.H2KlEEgXRIhnzU9AL0HIOxHCzOQFnvXsKJyPW--_xCc",
+			"type": "any",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2025-09-23T16:37:12.468Z",
+	"_postman_exported_using": "Postman/11.63.3"
+}

--- a/back/postman/ScalaLearning.postman_collection.json
+++ b/back/postman/ScalaLearning.postman_collection.json
@@ -1,0 +1,1080 @@
+{
+	"info": {
+		"_postman_id": "c4b9c939-4b2f-4644-82a2-3a1067dd6a8b",
+		"name": "ScalaLearning",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "39618805"
+	},
+	"item": [
+		{
+			"name": "Auth",
+			"item": [
+				{
+					"name": "Login_user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const jsonData = pm.response.json();\r",
+									"\r",
+									"if (jsonData.data && jsonData.data.token) {\r",
+									"    pm.environment.set(\"token\", jsonData.data.token);\r",
+									"    console.log(\"Token guardado:\", jsonData.data.token);\r",
+									"} else {\r",
+									"    console.error(\"No se encontró token en la respuesta\");\r",
+									"}\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"email\": \"admin@scala.com\",\r\n    \"password\": \"Admin1234\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/login",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET_verifytoken",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/verifytoken",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"verifytoken"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Users_CRUD",
+			"item": [
+				{
+					"name": "GET_users",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/users",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "POST_users",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"name\": \"Andrea Polo\",\r\n  \"email\": \"andrea@scala.com\",\r\n  \"role\": \"user\", \r\n  \"isAdmin\": false\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PUT_users/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{ \r\n    \"isAdmin\": true \r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/68bf15531d5ec28099fe51e2",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"68bf15531d5ec28099fe51e2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET_users/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/68bf2e192616da1852063c43",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"68bf2e192616da1852063c43"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE_users/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/68c9dcc3ae0737f31b96d407",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"68c9dcc3ae0737f31b96d407"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PATCH_/users/role/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{ \r\n    \"isAdmin\": true \r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/role/68bf15531d5ec28099fe51e2",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"role",
+								"68bf15531d5ec28099fe51e2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PATCH_users/restore/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/restore/68bf3a31a9ed39bcfb40a95f",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"restore",
+								"68bf3a31a9ed39bcfb40a95f"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PATCH_users/passwordReset",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"email\": \"admin@scala.com\",\r\n    \"newPassword\": \"Admin1234\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/passwordReset",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"passwordReset"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET_users/deleted",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"email\": \"admin@scala.com\",\r\n    \"password\": \"Admin1234\"\r\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/deleted",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"deleted"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Resources_CRUD",
+			"item": [
+				{
+					"name": "GET_resources",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/resources",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET/resources/id",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{baseUrl}}/resources/68c22af480f85343fb2bf920",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources",
+								"68c22af480f85343fb2bf920"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "POST_resources",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sectionId\": \"68cadd9354f9344f27defc83\",\r\n    \"name\": \"UCSS\",\r\n    \"description\": \" \",\r\n    \"links\": [\r\n        { \"label\": \" \", \"url\": \" \" }\r\n\r\n  ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/resources",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PATCH_restore/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/resources/restore/68b72fe4ff0cf9cd6dbc2ecf",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources",
+								"restore",
+								"68b72fe4ff0cf9cd6dbc2ecf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET_resources/section/id",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sectionId\": \"66d5c2a9f3f1c1a9b25c12e5\",\r\n    \"name\": \"Productos y Precios\",\r\n    \"description\": \"Probando recursos con auth\",\r\n    \"link\": \"https://drive.google.com/file/xxxxxx/view?usp=sharin\"\r\n}"
+						},
+						"url": {
+							"raw": "{{baseUrl}}/resources/section/68c9f2d8d6dbf0c558131e16",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources",
+								"section",
+								"68c9f2d8d6dbf0c558131e16"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PUT_resources/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"sectionId\": \"68c9f2d8d6dbf0c558131e16\",\r\n    \"links\": [\r\n        { \"label\": \" \", \"url\": \"https://docs.google.com/spreadsheets/d/1yNV6InDnRNSPjraCT2JDK0jkEZXyISHe6sZK8cmyug4/edit?gid=0#gid=0\" }\r\n\r\n  ],\r\n  \"isActive\": false\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/resources/68cae8c154f9344f27defc8f",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources",
+								"68cae8c154f9344f27defc8f"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE_resources/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/resources/68b72fe4ff0cf9cd6dbc2ecf",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"resources",
+								"68b72fe4ff0cf9cd6dbc2ecf"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Alliances_CRUD",
+			"item": [
+				{
+					"name": "GET_alliances",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/alliances",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"alliances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET_alliances/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/alliances/68c22bdb80f85343fb2bf923",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"alliances",
+								"68c22bdb80f85343fb2bf923"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "POST_alliances",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"name\": \"Universidad del Desarrollo\",\r\n  \"siglas\": \"UDD\",\r\n  \"url\": \"https://www.udd.cl/\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/alliances",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"alliances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PUT_alliances/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"url\": \"https://udd.com\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/alliances/68bf8efcd5e22cf935a01bcd",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"alliances",
+								"68bf8efcd5e22cf935a01bcd"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PATCH_alliances/restore/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/alliances/restore/68d1bf4d952445557f59bd8f",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"alliances",
+								"restore",
+								"68d1bf4d952445557f59bd8f"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE_alliances/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/alliances/68d1bf4d952445557f59bd8f",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"alliances",
+								"68d1bf4d952445557f59bd8f"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "SectionCRUD",
+			"item": [
+				{
+					"name": "GET_sections",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{baseUrl}}/sections",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"sections"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "POST_sections",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"title\": \"Chat IA\",\r\n  \"description\": \"Realiza scraping a la página\"\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/sections",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"sections"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET_sections/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/sections/68cade8354f9344f27defc87",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"sections",
+								"68cade8354f9344f27defc87"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PUT_sections",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"description\": \"Realiza scraping a la página.\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/sections/68cade8354f9344f27defc87",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"sections",
+								"68cade8354f9344f27defc87"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE_sections/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/sections/68cade8354f9344f27defc87",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"sections",
+								"68cade8354f9344f27defc87"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "PATCH_sections/restore/id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/sections/restore/68cade8354f9344f27defc87",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"sections",
+								"restore",
+								"68cade8354f9344f27defc87"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": ""
+		},
+		{
+			"key": "token",
+			"value": "",
+			"type": "default"
+		}
+	]
+}

--- a/back/src/app.ts
+++ b/back/src/app.ts
@@ -3,11 +3,16 @@ import router from './routes';
 import dotenv from 'dotenv';
 import connectDB from './config/database';
 import { errorHandler } from './utils/errorHandler';
+import cors from 'cors';
 
 dotenv.config();
 
 const app = express();
 connectDB();
+
+app.use(cors({
+  origin: 'http://localhost:5173' // Declaramos el puerto que usa el frontend
+}));
 
 app.use(express.json());
 


### PR DESCRIPTION
Este PR incluye las siguientes mejoras al backend:

1️⃣ **Instalación y configuración de CORS**
- Se instaló el paquete `cors` mediante npm.
- Se configuró en `app.ts` para habilitar que el frontend pueda hacer peticiones al backend desde otros puertos.
- Se agregó tipado de TypeScript instalando `@types/cors`.
- Esto permite que el navegador no bloquee las solicitudes HTTP entre el frontend y el backend en modo desarrollo.

2️⃣ **Creación de README**
- Se creó un archivo `README.md` en la raíz del backend.
- Contiene información básica del proyecto, cómo instalar dependencias, configurar la base de datos y correr el servidor.

3️⃣ **Carpeta de Postman**
- Se creó la carpeta `/postman` en la raíz del backend:
  - _ScalaLearning.postman_collection.json_ → rutas de la API.
  - _.ENV.postman_environment.json_ → variables ({{baseUrl}} y {{token}})
- También se incluye un `README.md` explicando cómo importar la colección en Postman.

4️⃣ **Estas mejoras nos facilita:**

- El desarrollo frontend-backend en local (CORS habilitado).
- La organización y documentación del backend.
- La realización de pruebas de los endpoints mediante Postman.

Estructura de la colección en Postman:
<img width="960" height="235" alt="image" src="https://github.com/user-attachments/assets/7aafcb52-0569-423c-9851-994f28f91407" />

BD en MongoDB Compass con datos de Scala:
<img width="1447" height="928" alt="image" src="https://github.com/user-attachments/assets/c68eb3af-4ac7-4434-aa91-3eb04d899a44" />


