### PR TITLE
feat(backend): control de visibilidad de documentos por rol y filtros

### DIFF
--- a/back/src/controllers/documentController.ts
+++ b/back/src/controllers/documentController.ts
@@ -6,13 +6,15 @@ import {
   deleteDocument,
   getDocumentFile,
   restoreDocument,
+  updateDocumentVisibility,
+  updateDocument,
 } from '../services/documentService';
 
 // ===== Subir documento =====
 export const uploadDocument = async (req: Request, res: Response) => {
   try {
     const file = req.file as Express.Multer.File | undefined;
-    const { name, description, category } = req.body;
+    const { name, description, category, visibleTo } = req.body;
 
     if (!file)
       return res.status(400).json({ message: 'Archivo (field "file") es requerido' });
@@ -20,6 +22,11 @@ export const uploadDocument = async (req: Request, res: Response) => {
       return res.status(400).json({ message: 'El campo "name" es requerido' });
     if (!category)
       return res.status(400).json({ message: 'El campo "category" es requerido' });
+
+const allowedRoles = ['admin', 'director', 'user'];
+const parsedVisibleTo = Array.isArray(visibleTo) && visibleTo.length > 0
+  ? visibleTo.filter((role: string) => allowedRoles.includes(role))
+  : ['admin', 'director', 'user']; // Valor por defecto
 
     const doc = await createDocument({
       name,
@@ -31,6 +38,7 @@ export const uploadDocument = async (req: Request, res: Response) => {
       uploadedBy: (req as any)?.user?.id || 'admin',
       size: file.size,
       originalName: file.originalname,
+      visibleTo: parsedVisibleTo,
     });
 
     return res.status(201).json({
@@ -38,7 +46,6 @@ export const uploadDocument = async (req: Request, res: Response) => {
       data: doc,
     });
   } catch (err) {
-    console.error('[uploadDocument]', err);
     return res.status(500).json({ message: 'Error al subir documento' });
   }
 };
@@ -50,11 +57,18 @@ export const listAllDocuments = async (req: Request, res: Response) => {
 
     if (req.query.category) filters.category = req.query.category;
     if (req.query.name) filters.name = req.query.name;
+    if (req.query.status) filters.status = req.query.status;
 
-    const docs = await listDocuments(filters);
-    return res.status(200).json({message: 'Documentos obtenidos correctamente', data: docs });
+    const userRole = (req as any)?.user?.role;
+    const isAdmin = (req as any)?.user?.isAdmin || false;
+
+    const docs = await listDocuments(filters, userRole, isAdmin);
+    
+    return res.status(200).json({
+      message: 'Documentos obtenidos correctamente',
+      data: docs,
+    });
   } catch (err) {
-    console.error('[listAllDocuments]', err);
     return res.status(500).json({ message: 'Error al listar documentos' });
   }
 };
@@ -62,17 +76,63 @@ export const listAllDocuments = async (req: Request, res: Response) => {
 // ===== Obtener documento por ID =====
 export const getOneDocument = async (req: Request, res: Response) => {
   try {
-    const doc = await getDocumentById(req.params.id);
+
+    const userRole = (req as any)?.user?.role;
+    const isAdmin = (req as any)?.user?.isAdmin || false;
+
+    const doc = await getDocumentById(req.params.id, userRole, isAdmin);
     if (!doc)
-      return res.status(404).json({ message: 'Documento no encontrado' });
+      return res.status(404).json({ message: 'Documento no encontrado o sin permiso de visualización' });
 
     return res.status(200).json({
       message: 'Documento obtenido correctamente',
       data: doc,
     });
   } catch (err) {
-    console.error('[getOneDocument]', err);
     return res.status(500).json({ message: 'Error al obtener documento' });
+  }
+};
+
+//Actualizar visibilidad de documento
+export const updateVisibility = async (req: Request, res: Response) => {
+  try {
+    const {id} = req.params;
+    const {visibleTo} = req.body; //Array de roles
+
+    if (!Array.isArray(visibleTo) || visibleTo.length === 0) {
+      return res.status(400).json({message: 'Debe especificar al menos un rol válido en visibleTo'});
+    }
+
+    const updateDoc = await updateDocumentVisibility(id, visibleTo);
+    if (!updateDoc) {
+      return res.status(404).json({message: 'Documento no encontrado o ya eliminado'});
+    }
+    return res.status(200).json({
+      message: 'Visibilidad de documento actualizada correctamente',
+      data: updateDoc,
+    });
+  } catch (error) {
+    return res.status(500).json({message: 'Error al actualizar visibilidad de documento'});
+  }
+};
+
+// ===== Actualizar documentos =====
+export const editDocument = async (req: Request, res: Response) => {
+  try {
+    const file = req.file as Express.Multer.File | undefined;
+    const data = req.body;  
+
+    const updatedDoc = await updateDocument(req.params.id, data, file);
+  
+    if (!updatedDoc)
+      return res.status(404).json({ message: 'Documento no encontrado o ya eliminado' });
+
+    return res.status(200).json({
+      message: 'Documento actualizado correctamente',
+      data: updatedDoc,
+    });
+  } catch (error) {
+    return res.status(500).json({ message: 'Error al actualizar documento' });
   }
 };
 
@@ -88,7 +148,6 @@ export const removeDocument = async (req: Request, res: Response) => {
       data: deletedDoc,
     });
   } catch (err) {
-    console.error('[removeDocument]', err);
     return res.status(500).json({ message: 'Error al eliminar documento' });
   }
 };
@@ -127,7 +186,6 @@ export const downloadDocument = async (req: Request, res: Response) => {
       }
     });
   } catch (err) {
-    console.error('[downloadDocument]', err);
     return res.status(500).json({ message: 'Error interno al descargar documento' });
   }
 };

--- a/back/src/models/Document.ts
+++ b/back/src/models/Document.ts
@@ -4,8 +4,9 @@ const DocumentSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
     description: { type: String },
-    category: { type: String,
-      enum: ['manual', 'guia', 'politicas', 'faqs', 'otros'],
+    category: {
+      type: String,
+      enum: ['manual', 'informe', 'guia', 'politicas', 'faqs', 'otros'],
       required: true
     },
     type: { type: String, required: true }, // MIME (e.g., application/pdf)
@@ -16,6 +17,11 @@ const DocumentSchema = new mongoose.Schema(
     size: { type: Number },
     originalName: { type: String },
     isDeleted: { type: Boolean, default: false }, // ✅ Soft delete
+    visibleTo: {
+      type: [String],
+      enum: ['admin', 'director', 'user'],
+      default: ['admin', 'director', 'user']
+    }
   },
   { versionKey: false, timestamps: false }
 );

--- a/back/src/routes/documentRoutes.ts
+++ b/back/src/routes/documentRoutes.ts
@@ -9,6 +9,8 @@ import {
   removeDocument,
   downloadDocument,
   restoreDocuments,
+  updateVisibility,
+  editDocument,
 } from '../controllers/documentController';
 import { authMiddleware } from '../middlewares/auth.middleware';
 import { verifyAdmin } from '../middlewares/verifyAdmin.middleware';
@@ -49,15 +51,16 @@ const upload = multer({
 });
 
 // === Endpoints ===
-// ✅ Solo ADMIN puede subir o eliminar
+// ✅ Solo ADMIN puede subir, eliminar y restaurar archivos y cambiar visibilidad
 documentRouter.post('/upload', authMiddleware, verifyAdmin, upload.single('file'), uploadDocument);
+documentRouter.put('/:id', authMiddleware, verifyAdmin, upload.single('file'), editDocument);
 documentRouter.delete('/:id', authMiddleware, verifyAdmin, removeDocument);
 documentRouter.patch('/restore/:id', authMiddleware, verifyAdmin, restoreDocuments);
+documentRouter.patch('/:id/visibility', authMiddleware, verifyAdmin, updateVisibility);
 
 // ✅ Usuarios autenticados (user, director) pueden ver y descargar
 documentRouter.get('/', authMiddleware, listAllDocuments);
 documentRouter.get('/:id', authMiddleware, getOneDocument);
-
 documentRouter.get('/download/:id', authMiddleware, downloadDocument);
 
 export default documentRouter;


### PR DESCRIPTION
Este PR implementa mejoras en la gestión de **documentos** del módulo de administrador, incluyendo control de visibilidad por rol y filtros para documentos activos o eliminados.

**Cambios implementados**

**1. Control de visibilidad por roles** (visibleTo): 
- El admin puede definir qué roles (user, director) pueden ver cada documento.

**2. Actualización de endpoints:**
- PUT /documents/:id/visibility → actualiza visibilidad.
- PUT /documents/:id → permite editar nombre, descripción o categoría.
- GET /documents?status=active|deleted → nuevo filtro por estado.
- Validaciones de acceso y permisos
- Solo el administrador puede modificar visibilidad o eliminar/restaurar archivos.
- Usuarios autenticados solo pueden visualizar documentos visibles por su rol y descargar.

**3. Ajustes técnicos:**
- Refactor de documentService y documentController para integrar el nuevo campo visibleTo y filtros por estado.
- Manejo dinámico de queries según rol y estado del documento.
- Mejora en la estructura REST y consistencia entre rutas.
- Validación adicional en endpoints de edición y carga de documentos.

**4. Pruebas realizadas (Postman):**
✅ Subida de documentos por administrador.
✅ Visualización según rol (user, director, admin).
✅ Restricción de acceso a documentos no visibles.
✅ Filtrado en Postman por estado (active, deleted, all).
✅ Edición y actualización de visibilidad desde el backend.
